### PR TITLE
[fix] parsing fractional values on all all system cultures

### DIFF
--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Baum2/Libraries/MiniJSON/MiniJSON.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Baum2/Libraries/MiniJSON/MiniJSON.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -76,6 +77,8 @@ namespace Baum2.MiniJSON
     /// </summary>
     public static class Json
     {
+        static CultureInfo culture = new CultureInfo("en-US");
+
         /// <summary>
         /// Parses the string json into a value
         /// </summary>
@@ -329,7 +332,7 @@ namespace Baum2.MiniJSON
 				*/
 
                 float parsedFloat;
-                float.TryParse(number, out parsedFloat);
+                float.TryParse(number, NumberStyles.Any, culture, out parsedFloat);
                 return parsedFloat;
             }
 


### PR DESCRIPTION
Some systems where the default delimiter is not a . the layout gets messed up because the delimiter is not interpreted correctly.
E.g. on German systems the 0.5 gets parsed to 0,5 which in turn messes up the layout in unity.

To fix that we just need to define the system culture when parsing floats
static CultureInfo culture = new CultureInfo("en-US");