### PR TITLE
Features/non destructive updates

### DIFF
--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/MasterPrefabs.meta
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/MasterPrefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62ebdd9dc7c099e499b993a93f1741b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/MasterPrefabs/GameSample.meta
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/MasterPrefabs/GameSample.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44cc4b4243ea9534f9ab1531cadd7fdc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/EditorUtil.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/EditorUtil.cs
@@ -126,12 +126,19 @@ namespace I0plus.XdUnityUI.Editor
             return FindFolderAssetPath("_XdUnityUISprites");
         }
 
-        public static string GetOutputPrefabsFolderAssetPath()
+        public static string GetMasterPrefabFolder()
         {
             var path = FindFolderAssetPath("_XdUnityUIPrefabs1", false);
             if (path != null) return path;
             return FindFolderAssetPath("_XdUnityUIPrefabs");
         }
+
+        public static string GetUserPrefabFolder()
+        {
+            var path = FindFolderAssetPath("_XdUserUIPrefabs1", false);
+            if (path != null) return path;
+            return FindFolderAssetPath("_XdUserUIPrefabs");
+        }     
 
         public static string GetFontsAssetPath()
         {
@@ -145,6 +152,16 @@ namespace I0plus.XdUnityUI.Editor
             var path = FindFolderAssetPath("_XdUnityUIAtlas1", false);
             if (path != null) return path;
             return FindFolderAssetPath("_XdUnityUIAtlas");
+        }
+
+        public static void CreateDirectoryIfNotExistant(string path)
+        {
+            var fullPath = Path.Combine(Application.dataPath.Replace("Assets", ""), path);
+            
+            if(!Directory.Exists(fullPath))
+            {
+                Directory.CreateDirectory(fullPath);
+            }
         }
 
         /// <summary>
@@ -165,7 +182,7 @@ namespace I0plus.XdUnityUI.Editor
         {
             // サブディレクトリ名を取得する
             var directoryName = Path.GetFileName(Path.GetFileName(prefabPath));
-            var directoryPath = GetOutputPrefabsFolderAssetPath();
+            var directoryPath = GetMasterPrefabFolder();
             var directoryFullPath = Path.Combine(directoryPath, directoryName);
             return directoryFullPath;
         }

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/Element.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/Element.cs
@@ -94,12 +94,11 @@ namespace I0plus.XdUnityUI.Editor
                     if (existingGo == null)
                     {
                         go = InstantiateUiGameObject();
-                        //we store new prefabs in a stack since we need to convert them into actual prefabs back to front in order for nesting to work properly
-                        renderContext.NewPrefabs.Push(go);
                     }
                     else
                     {
                         go = (GameObject)PrefabUtility.InstantiatePrefab(renderContext.ExistingPrefabs.First(x => x.name == PrefabID));
+                        go.name = name;
                     }
                 }
                 else
@@ -115,10 +114,7 @@ namespace I0plus.XdUnityUI.Editor
         {
             GameObject go;
 
-            if (!IsPrefab)
-                go = new GameObject(name);
-            else
-                go = new GameObject(PrefabID);
+            go = new GameObject(name);
 
             go.AddComponent<RectTransform>();
             ElementUtil.SetLayer(go, Layer);
@@ -126,17 +122,15 @@ namespace I0plus.XdUnityUI.Editor
             return go;
         }
 
-        //since we do not want to read components to a prefab we use this method to add components to elements
+        //since we do not want to readd components to a prefab we use this method to add components to elements
         protected T AddComponent<T>() where T : Component
         {
-            if(!this.IsPrefab || PrefabUtility.GetPrefabAssetType(go) == PrefabAssetType.NotAPrefab || PrefabUtility.GetPrefabAssetType(go) == PrefabAssetType.MissingAsset)
-            {
-                return go.AddComponent<T>();
-            }
-            else
-            {
-                return go.GetComponent<T>();
-            }
+            T component = this.go.GetComponent<T>();
+
+            if (component == null)
+                component = this.go.AddComponent<T>();
+
+            return component;
         }
     }
 }

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/Element.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/Element.cs
@@ -25,6 +25,11 @@ namespace I0plus.XdUnityUI.Editor
             get;
             private set;
         }
+        public string PrefabID
+        {
+            get;
+            private set;
+        }
 
         private GameObject go;
 
@@ -41,6 +46,7 @@ namespace I0plus.XdUnityUI.Editor
             LayoutElementJson = json.GetDic("layout_element");
 
             IsPrefab = json.Get("symbolInstance") != null;
+            PrefabID = json.Get("symbolID");
         }
 
         public string Name => name;
@@ -72,7 +78,6 @@ namespace I0plus.XdUnityUI.Editor
             if (parentPrefab != null)
             {
                 //...and if so check if the element we want to create here has already been created as part of the prefab...
-                //TODO: This will lead to problems if we have mutliple transforms in prefab with the same name see issue https://github.com/KlingOne/XdUnityUI/issues/4
                 go = parentPrefab.GetComponentsInChildren<Transform>().FirstOrDefault(x => x.name == this.Name && x.gameObject != parentObject)?.gameObject;
                 isPrefabChild = true;
             }
@@ -83,8 +88,7 @@ namespace I0plus.XdUnityUI.Editor
                 if (this.IsPrefab)
                 {
                     //check if there already is a existing prefab with the same name from a previous artboard generation
-                    //TODO: Check if prefab names are truly unique or if the components in Adobe XD can have the same name
-                    var existingGo = renderContext.ExistingPrefabs.FirstOrDefault(x => x.name == name);
+                    var existingGo = renderContext.ExistingPrefabs.FirstOrDefault(x => x.name == PrefabID);
 
                     //...if not we register this new gameObject to be saved out as a prefab
                     if (existingGo == null)
@@ -95,7 +99,7 @@ namespace I0plus.XdUnityUI.Editor
                     }
                     else
                     {
-                        go = (GameObject)PrefabUtility.InstantiatePrefab(renderContext.ExistingPrefabs.First(x => x.name == name));
+                        go = (GameObject)PrefabUtility.InstantiatePrefab(renderContext.ExistingPrefabs.First(x => x.name == PrefabID));
                     }
                 }
                 else
@@ -109,7 +113,13 @@ namespace I0plus.XdUnityUI.Editor
 
         protected GameObject InstantiateUiGameObject()
         {
-            GameObject go = new GameObject(name);
+            GameObject go;
+
+            if (!IsPrefab)
+                go = new GameObject(name);
+            else
+                go = new GameObject(PrefabID);
+
             go.AddComponent<RectTransform>();
             ElementUtil.SetLayer(go, Layer);
             if (Active != null) go.SetActive(Active.Value);

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
@@ -157,14 +157,16 @@ namespace I0plus.XdUnityUI.Editor
                 {
                     if (PrefabUtility.GetPrefabAssetType(go) == PrefabAssetType.NotAPrefab)
                     {
-                        var nestedPrefabDirectory = Path.Combine(Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath()), "Components");
+                        //var nestedPrefabDirectory = Path.Combine(Path.Combine(EditorUtil.GetMasterPrefabsFolderAssetPath()), "Components");
 
-                        if (!Directory.Exists(nestedPrefabDirectory))
-                            Directory.CreateDirectory(nestedPrefabDirectory);
+                        //if (!Directory.Exists(nestedPrefabDirectory))
+                        //    Directory.CreateDirectory(nestedPrefabDirectory);
 
-                        var fileName = Path.Combine(nestedPrefabDirectory, go.name + ".prefab");
+                        //var fileName = Path.Combine(nestedPrefabDirectory, go.name + ".prefab");
 
-                        renderContext.ExistingPrefabs.Add(UnityEditor.PrefabUtility.SaveAsPrefabAssetAndConnect(go, fileName , UnityEditor.InteractionMode.AutomatedAction));
+                        var prefab = EditorUtil.SaveMasterAndUserPrefab(go, "Components", element.Name);
+
+                        renderContext.ExistingPrefabs.Add(prefab);
                     }
                 }
 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
@@ -157,15 +157,16 @@ namespace I0plus.XdUnityUI.Editor
                 {
                     if (PrefabUtility.GetPrefabAssetType(go) == PrefabAssetType.NotAPrefab)
                     {
-                        //var nestedPrefabDirectory = Path.Combine(Path.Combine(EditorUtil.GetMasterPrefabsFolderAssetPath()), "Components");
+                        var nestedPrefabDirectory = Path.Combine(EditorUtil.GetMasterPrefabFolder(), "Components");
 
-                        //if (!Directory.Exists(nestedPrefabDirectory))
-                        //    Directory.CreateDirectory(nestedPrefabDirectory);
+                        var fileName = Path.Combine(nestedPrefabDirectory, element.Name + ".prefab");
 
-                        //var fileName = Path.Combine(nestedPrefabDirectory, go.name + ".prefab");
+                        EditorUtil.CreateDirectoryIfNotExistant(nestedPrefabDirectory);
 
-                        var prefab = EditorUtil.SaveMasterAndUserPrefab(go, "Components", element.Name);
+                        var prefab = UnityEditor.PrefabUtility.SaveAsPrefabAssetAndConnect(go, fileName, UnityEditor.InteractionMode.AutomatedAction);
 
+                        //we need to rename the gameObject to the prefab ID so that we can later on recognize it when we encounter an element wit the same PrefabID
+                        prefab.name = element.PrefabID;
                         renderContext.ExistingPrefabs.Add(prefab);
                     }
                 }

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/GroupElement.cs
@@ -153,19 +153,20 @@ namespace I0plus.XdUnityUI.Editor
                 var go = element.Render(renderContext, parent);
                 if (go.transform.parent != parent.transform) Debug.Log("No parent set" + go.name);
 
-                //if (element.IsPrefab)
-                //{
-                //    //TODO: Check if prefab names are truly unique or if the components in Adobe XD can have the same name
-                //    if(!renderContext.Prefabs.ContainsKey(go.name))
-                //        renderContext.Prefabs.Add(go.name,go);
-                //    else
-                //    {
-                //        var oldGo = go;
-                //        go = (GameObject)PrefabUtility.InstantiatePrefab(renderContext.Prefabs[oldGo.name],oldGo.transform.parent);
+                if(element.IsPrefab)
+                {
+                    if (PrefabUtility.GetPrefabAssetType(go) == PrefabAssetType.NotAPrefab)
+                    {
+                        var nestedPrefabDirectory = Path.Combine(Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath()), "Components");
 
-                //        GameObject.DestroyImmediate(oldGo);
-                //    }
-                //}
+                        if (!Directory.Exists(nestedPrefabDirectory))
+                            Directory.CreateDirectory(nestedPrefabDirectory);
+
+                        var fileName = Path.Combine(nestedPrefabDirectory, go.name + ".prefab");
+
+                        renderContext.ExistingPrefabs.Add(UnityEditor.PrefabUtility.SaveAsPrefabAssetAndConnect(go, fileName , UnityEditor.InteractionMode.AutomatedAction));
+                    }
+                }
 
                 list.Add(new Tuple<GameObject, Element>(go, element));
                 if (callback != null) callback.Invoke(go, element);

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ImageElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ImageElement.cs
@@ -33,49 +33,49 @@ namespace I0plus.XdUnityUI.Editor
             var image = go.GetComponent<Image>();
 
             //if a image component is already present this means this go is part of a prefab and we skip the image setup since it has already been done
-            //TODO: check if some parts still need to be done for prefabs that have local modifications
             if (image == null)
             {
-                image = this.AddComponent<Image>();
-                var sourceImage = ImageJson.Get("source_image");
-                if (sourceImage != null)
-                    image.sprite = renderContext.GetSprite(sourceImage);
-
-                image.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
-                var raycastTarget = ImageJson.GetBool("raycast_target");
-                if (raycastTarget != null)
-                    image.raycastTarget = raycastTarget.Value;
-
-                image.type = Image.Type.Sliced;
-                var imageType = ImageJson.Get("image_type");
-                if (imageType != null)
-                    switch (imageType.ToLower())
-                    {
-                        case "sliced":
-                            image.type = Image.Type.Sliced;
-                            break;
-                        case "filled":
-                            image.type = Image.Type.Filled;
-                            break;
-                        case "tiled":
-                            image.type = Image.Type.Tiled;
-                            break;
-                        case "simple":
-                            image.type = Image.Type.Simple;
-                            break;
-                        default:
-                            Debug.LogAssertion("[XdUnityUI] unknown image_type:" + imageType);
-                            break;
-                    }
-
-                var preserveAspect = ImageJson.GetBool("preserve_aspect");
-                if (preserveAspect != null && preserveAspect.Value)
-                {
-                    // アスペクト比を保つ場合はSimpleにする
-                    image.type = Image.Type.Simple;
-                    image.preserveAspect = true;
-                }
+                image = this.AddComponent<Image>();        
             }
+
+            image.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+            var raycastTarget = ImageJson.GetBool("raycast_target");
+            if (raycastTarget != null)
+                image.raycastTarget = raycastTarget.Value;
+
+            image.type = Image.Type.Sliced;
+            var imageType = ImageJson.Get("image_type");
+            if (imageType != null)
+                switch (imageType.ToLower())
+                {
+                    case "sliced":
+                        image.type = Image.Type.Sliced;
+                        break;
+                    case "filled":
+                        image.type = Image.Type.Filled;
+                        break;
+                    case "tiled":
+                        image.type = Image.Type.Tiled;
+                        break;
+                    case "simple":
+                        image.type = Image.Type.Simple;
+                        break;
+                    default:
+                        Debug.LogAssertion("[XdUnityUI] unknown image_type:" + imageType);
+                        break;
+                }
+
+            var preserveAspect = ImageJson.GetBool("preserve_aspect");
+            if (preserveAspect != null && preserveAspect.Value)
+            {
+                // アスペクト比を保つ場合はSimpleにする
+                image.type = Image.Type.Simple;
+                image.preserveAspect = true;
+            }
+
+            var sourceImage = ImageJson.Get("source_image");
+            if (sourceImage != null)
+                image.sprite = renderContext.GetSprite(sourceImage);
 
 
             ElementUtil.SetupLayoutElement(go, LayoutElementJson);

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ImageElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ImageElement.cs
@@ -30,13 +30,7 @@ namespace I0plus.XdUnityUI.Editor
                 //親のパラメータがある場合､親にする 後のAnchor定義のため
                 rect.SetParent(parentObject.transform);
 
-            var image = go.GetComponent<Image>();
-
-            //if a image component is already present this means this go is part of a prefab and we skip the image setup since it has already been done
-            if (image == null)
-            {
-                image = this.AddComponent<Image>();        
-            }
+            var image = this.AddComponent<Image>();        
 
             image.color = new Color(1.0f, 1.0f, 1.0f, 1.0f);
             var raycastTarget = ImageJson.GetBool("raycast_target");

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/InputElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/InputElement.cs
@@ -23,7 +23,8 @@ namespace I0plus.XdUnityUI.Editor
 
             var children = RenderChildren(renderContext, go);
 
-            var inputField = go.AddComponent<InputField>();
+            var inputField = this.AddComponent<InputField>();
+
             inputField.transition = Selectable.Transition.None;
             if (InputJson != null)
             {

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/SliderElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/SliderElement.cs
@@ -21,7 +21,7 @@ namespace I0plus.XdUnityUI.Editor
         {
             var go = CreateSelf(renderContext, parentObject);
 
-            var slider = go.AddComponent<Slider>();
+            var slider = this.AddComponent<Slider>();
 
             var children = RenderChildren(renderContext, go);
 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/TextElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/TextElement.cs
@@ -35,35 +35,29 @@ namespace I0plus.XdUnityUI.Editor
             var align = _textJson.Get("align");
             var type = _textJson.Get("textType");
 
-            var text = go.GetComponent<Text>();
+            var text = this.AddComponent<Text>();
+            
+            // 検索するフォント名を決定する
+            var fontFilename = fontName;
 
-            //if a text component is already present this means this go is part of a prefab and we skip the font generation
-            if (text == null)
+            if (_textJson.ContainsKey("style"))
             {
-                text = this.AddComponent<Text>();
-
-                // 検索するフォント名を決定する
-                var fontFilename = fontName;
-
-                if (_textJson.ContainsKey("style"))
+                var style = _textJson.Get("style");
+                fontFilename += "-" + style;
+                if (style.Contains("normal") || style.Contains("medium"))
                 {
-                    var style = _textJson.Get("style");
-                    fontFilename += "-" + style;
-                    if (style.Contains("normal") || style.Contains("medium"))
-                    {
-                        text.fontStyle = FontStyle.Normal;
-                    }
-
-                    if (style.Contains("bold"))
-                    {
-                        text.fontStyle = FontStyle.Bold;
-                    }
+                    text.fontStyle = FontStyle.Normal;
                 }
 
-                text.fontSize = Mathf.RoundToInt(fontSize.Value);
-                text.font = renderContext.GetFont(fontFilename);
+                if (style.Contains("bold"))
+                {
+                    text.fontStyle = FontStyle.Bold;
+                }
             }
-         
+
+            text.fontSize = Mathf.RoundToInt(fontSize.Value);
+            text.font = renderContext.GetFont(fontFilename);
+
             text.text = message;
             text.color = Color.black;
 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/TextMeshProElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/TextMeshProElement.cs
@@ -41,14 +41,9 @@ namespace I0plus.XdUnityUI.Editor
             var align = _textJson.Get("align");
             var type = _textJson.Get("textType");
 
-            var text = go.GetComponent<TextMeshProUGUI>();
+            var text = this.AddComponent<TextMeshProUGUI>();
 
-            //if a text component is already present this means this go is part of a prefab and we skip the font generation
-            if (text == null)
-            {
-                text = go.AddComponent<TextMeshProUGUI>();
-                text.font = renderer.GetTMPFontAsset(fontName, fontStyle);
-            }
+            text.font = renderer.GetTMPFontAsset(fontName, fontStyle);
 
             text.text = message;
             text.fontSize = fontSize.Value;

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ToggleElement.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Elements/ToggleElement.cs
@@ -22,22 +22,16 @@ namespace I0plus.XdUnityUI.Editor
 
             var children = RenderChildren(renderContext, go);
 
-            var toggle = go.GetComponent<Toggle>();
+            var toggle = this.AddComponent<Toggle>();
 
-            //if a text toggle is already present this means this go is part of a prefab and we skip the toggle group assignment
-            if (toggle == null)
+            // トグルグループ名
+            var group = _toggleJson.Get("group");
+            if (group != null)
             {
-                toggle = go.AddComponent<Toggle>();
-                // トグルグループ名
-                var group = _toggleJson.Get("group");
-                if (group != null)
-                {
-                    var toggleGroup = renderContext.GetToggleGroup(group);
-                    //Debug.Log("toggleGroup:" + toggleGroup);
-                    toggle.group = toggleGroup;
-                }
+                var toggleGroup = renderContext.GetToggleGroup(group);
+                //Debug.Log("toggleGroup:" + toggleGroup);
+                toggle.group = toggleGroup;
             }
-
 
             var targetImage =
                 ElementUtil.FindComponentByClassName<Image>(children, _toggleJson.Get("target_graphic_class"));

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Importer.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Importer.cs
@@ -320,18 +320,8 @@ namespace I0plus.XdUnityUI.Editor
                         Path.Combine(EditorUtil.GetOutputSpritesFolderAssetPath(), subFolderName);
                     var fontAssetPath = EditorUtil.GetFontsAssetPath();
                     var creator = new PrefabCreator(spriteOutputFolderAssetPath, fontAssetPath, layoutFilePath, prefabs);
-                    go = creator.Create();
-                    var saveAssetPath =
-                        Path.Combine(Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath(),
-                            subFolderName), prefabFileName);
-#if UNITY_2018_3_OR_NEWER
-                    var savedAsset = PrefabUtility.SaveAsPrefabAsset(go, saveAssetPath);
-                    Debug.Log("[XdUnityUI] Created prefab: " + saveAssetPath, savedAsset);
-#else
-                    Object originalPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(savePath);
-                    if (originalPrefab == null) originalPrefab = PrefabUtility.CreateEmptyPrefab(savePath);
-                    PrefabUtility.ReplacePrefab(go, originalPrefab, ReplacePrefabOptions.ReplaceNameBased);
-#endif
+                    go = creator.Create(subFolderName);
+
                 }
                 catch (Exception ex)
                 {

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Importer.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/Importer.cs
@@ -238,10 +238,10 @@ namespace I0plus.XdUnityUI.Editor
                     changed = true;
                 }
 
-                var prefabsOutputPath = Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath(), subFolderName);
+                var prefabsOutputPath = Path.Combine(EditorUtil.GetMasterPrefabFolder(), subFolderName);
                 if (!Directory.Exists(prefabsOutputPath))
                 {
-                    AssetDatabase.CreateFolder(EditorUtil.GetOutputPrefabsFolderAssetPath(),
+                    AssetDatabase.CreateFolder(EditorUtil.GetMasterPrefabFolder(),
                         subFolderName);
                     changed = true;
                 }

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/PrefabCreator.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/PrefabCreator.cs
@@ -37,7 +37,7 @@ namespace I0plus.XdUnityUI.Editor
             this.nestedPrefabs = prefabs;
         }
 
-        public GameObject Create()
+        public GameObject Create(string subFolderName)
         {
             if (EditorApplication.isPlaying) EditorApplication.isPlaying = false;
 
@@ -67,21 +67,19 @@ namespace I0plus.XdUnityUI.Editor
                 }
             }
 
-            foreach(var prefab in renderer.NewPrefabs.ToList())
-            {
-
-                //if we haven't created a prefab out of the referenced GO we do so now
-                if (PrefabUtility.GetPrefabAssetType(prefab) == PrefabAssetType.NotAPrefab)
-                {
-                    //TODO: Ugly path generation
-                    var nestedPrefabDirectory = Path.Combine(Application.dataPath.Replace("Assets", ""), Path.Combine(Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath()), "Components"));
-
-                    if (!Directory.Exists(nestedPrefabDirectory))
-                        Directory.CreateDirectory(nestedPrefabDirectory);
-
-                    nestedPrefabs.Add(UnityEditor.PrefabUtility.SaveAsPrefabAssetAndConnect(prefab, Path.Combine(nestedPrefabDirectory, prefab.name + ".prefab"), UnityEditor.InteractionMode.AutomatedAction));
-                }
-            }
+            //Path.Combine(nestedPrefabDirectory, go.name + ".prefab")
+            var prefabFileName = rootJson.Get("id");
+            var saveAssetPath = 
+            Path.Combine(Path.Combine(EditorUtil.GetOutputPrefabsFolderAssetPath(),
+                subFolderName), prefabFileName)+".prefab";
+#if UNITY_2018_3_OR_NEWER
+            var savedAsset = UnityEditor.PrefabUtility.SaveAsPrefabAssetAndConnect(root,saveAssetPath, UnityEditor.InteractionMode.AutomatedAction);
+                    Debug.Log("[XdUnityUI] Created prefab: " + saveAssetPath, savedAsset);
+        #else
+                            Object originalPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(savePath);
+                            if (originalPrefab == null) originalPrefab = PrefabUtility.CreateEmptyPrefab(savePath);
+                            PrefabUtility.ReplacePrefab(go, originalPrefab, ReplacePrefabOptions.ReplaceNameBased);
+        #endif
 
             return root;
         }

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/RenderContext.cs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/Scripts/Editor/RenderContext.cs
@@ -15,7 +15,6 @@ namespace I0plus.XdUnityUI.Editor
         private readonly string spriteRootPath;
         private readonly string fontRootPath;
         public List<GameObject> ExistingPrefabs { get; private set; }
-        public Stack<GameObject> NewPrefabs { get; private set; } = new Stack<GameObject>();
         public Dictionary<string, GameObject> ToggleGroupMap { get; } = new Dictionary<string, GameObject>();
 
         public ToggleGroup GetToggleGroup(string name)

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs.meta
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35231bc687ed4054682f2a535c019454
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs/_XdUserUIPrefabs
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs/_XdUserUIPrefabs
@@ -1,0 +1,1 @@
+Don't delete this file.

--- a/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs/_XdUserUIPrefabs.meta
+++ b/Develop/UnityProject/Assets/I0plus/XdUnityUI/UserPrefabs/_XdUserUIPrefabs.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 580068897cd74fe4baa666064e1e39d9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Develop/XdUnityUIExport/main.js
+++ b/Develop/XdUnityUIExport/main.js
@@ -4356,7 +4356,15 @@ async function createRoot(renditions, outputFolder, root) {
             symbolInstance: getUnityName(node)
           })
         }
+
+        Object.assign(json, {
+          symbolID: node.symbolId
+        })
+
       case 'Artboard':
+        Object.assign(json, {
+          id: node.guid
+        })
       case 'ScrollableGroup':
       case 'Group':
       case 'RepeatGrid':


### PR DESCRIPTION
I've implemented the functionality to keep changes made to prefabs when an update design gets imported in Unity.

The whole thing was way more complicated then I initially thought since unity does not allow us to replace nested prefabs.
Therefore I'm not quite satisfied with the current implementation but since you are also working on prefabs in your repository I still decided to make this pull request so that we can discuss our approaches.

The basic logic behind my aproach is:

For the Artboard root prefab we now generate 2 Prefabs.
1. A "normal" prefab (MasterPrefab) in the MasterPrefabs folder that has the guid of the symbolInstance as its name
2. A prefab variant (UserPrefab) derived from the Masterprefab that gets stored with a proper name in the UserPrefabs folder

This way the user can work with the UserPrefab an make changes to it without loosing them when the MasterPrefab gets overridden next time the UI gets updated by a Designer
TODO:
Currently this system only can keep changes that are made to the root prefab (ArtBoard). All changes that are made to components (nested prefbs) will still be overriden on the next ui import
The problem here is that unity does not allow us to replace components in a prefab and therefore we cant change the nested prefabs to prefab variants in the UserPrefab